### PR TITLE
[Task] 서적 검색 및 목록 테스트 코드 작성 및 화면 작성 #2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "extends": [
     "prettier",
     "eslint:recommended",
+    "plugin:tailwindcss/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
@@ -18,9 +19,17 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "react", "prettier", "import", "react-hooks"],
+  "plugins": [
+    "@typescript-eslint",
+    "react", 
+    "import", 
+    "react-hooks",
+    "prettier"
+  ],
   "rules": {
-    "prettier/prettier": "warn"
+    "prettier/prettier": ["warn", {
+      "printWidth": 120
+    }]
   },
   "settings": {
     "import/parsers": {

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "itbook.store",
+        port: "",
+        pathname: "/img/**",
+      },
+    ],
+  },
+};
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-tailwindcss": "^3.13.0",
         "postcss": "^8",
         "prettier": "^3.1.1",
         "tailwindcss": "^3.3.0",
@@ -1971,6 +1972,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.13.0.tgz",
+      "integrity": "sha512-Fcep4KDRLWaK3KmkQbdyKHG0P4GdXFmXdDaweTIPcgOP60OOuWFbh1++dufRT28Q4zpKTKaHwTsXPJ4O/EjU2Q==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.3.2"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-tailwindcss": "^3.13.0",
     "postcss": "^8",
     "prettier": "^3.1.1",
     "tailwindcss": "^3.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: "http://127.0.0.1:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/src/api/fetch.ts
+++ b/src/api/fetch.ts
@@ -1,0 +1,12 @@
+import type { BookDetailResponse, BookListResponse } from "./model";
+
+const API_URL = "https://api.itbook.store/1.0";
+
+export async function getBooks(keyword: string, page?: number): Promise<BookListResponse> {
+  if (!keyword) throw new Error("검색 키워드를 입력해야 합니다.");
+  return fetch(`${API_URL}/search/${keyword}/${page ?? ""}`).then((res) => res.json());
+}
+
+export async function getBookDetail(isbn13: string): Promise<BookDetailResponse> {
+  return fetch(`${API_URL}/books/${isbn13}`).then((res) => res.json());
+}

--- a/src/api/model.ts
+++ b/src/api/model.ts
@@ -1,0 +1,26 @@
+export interface BookListResponse {
+  total: string;
+  page: string;
+  books: BookListItem[];
+}
+
+export type BookListItem = {
+  title: string;
+  subtitle: string;
+  isbn13: string;
+  price: string;
+  image: string;
+  url: string;
+};
+
+export interface BookDetailResponse {
+  title: string;
+  subtitle: string;
+  authors: string;
+  publisher: string;
+  pages: string;
+  rating: string;
+  desc: string;
+  price: string;
+  image: string;
+}

--- a/src/app/(books)/layout.tsx
+++ b/src/app/(books)/layout.tsx
@@ -5,8 +5,8 @@ export default function HomeLayout({ children }: React.PropsWithChildren) {
         <h1 className="text-3xl font-extrabold text-slate-900 md:text-4xl">도서 검색 서비스</h1>
         <h2 className="text-sm font-bold text-slate-500 md:text-lg">검색하고 싶은 책의 제목을 입력해보세요!</h2>
       </header>
-      <main className="container mx-auto pb-20">{children}</main>
-      <footer className="absolute bottom-0 grid h-20 w-full place-items-center gap-4">
+      <main className="container mx-auto pb-20 md:pb-32">{children}</main>
+      <footer className="absolute bottom-0 grid h-20 w-full place-items-center gap-4 md:h-32">
         <p className="text-sm font-bold text-slate-500 md:text-lg">
           <a href="https://itbook.store/">itbook.store</a>
         </p>

--- a/src/app/(books)/layout.tsx
+++ b/src/app/(books)/layout.tsx
@@ -1,0 +1,16 @@
+export default function HomeLayout({ children }: React.PropsWithChildren) {
+  return (
+    <main className="container relative mx-auto min-h-screen">
+      <header className="grid place-items-center gap-4 py-12 md:gap-10 md:py-20">
+        <h1 className="text-3xl font-extrabold text-slate-900 md:text-4xl">도서 검색 서비스</h1>
+        <h2 className="text-sm font-bold text-slate-500 md:text-lg">검색하고 싶은 책의 제목을 입력해보세요!</h2>
+      </header>
+      <main className="container mx-auto pb-20">{children}</main>
+      <footer className="absolute bottom-0 grid h-20 w-full place-items-center gap-4">
+        <p className="text-sm font-bold text-slate-500 md:text-lg">
+          <a href="https://itbook.store/">itbook.store</a>
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/src/app/(books)/page.tsx
+++ b/src/app/(books)/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { getBooks } from "@/api/fetch";
+import SearchForm from "./ui/SearchForm";
+import BookCard from "./ui/BookCard";
+import { BookListItem } from "@/api/model";
+
+export default function Page() {
+  const total = useRef(0);
+  const page = useRef(1);
+
+  const [books, setBooks] = useState<BookListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  async function handleSubmit(searchText: string) {
+    const text = searchText.trim();
+    if (text.length === 0) {
+      return;
+    }
+
+    setLoaded(false);
+    setLoading(true);
+    const res = await getBooks(text);
+    setBooks(res.books);
+    setLoading(false);
+    setLoaded(true);
+
+    total.current = +res.total;
+    page.current = +res.page;
+    window.scrollTo({ top: 0 });
+  }
+
+  function handleTextChange() {
+    setLoaded(false);
+  }
+
+  return (
+    <div className="p-4 sm:pb-4">
+      <section className="sticky top-2 z-10 mx-auto grid place-items-center md:max-w-3/4">
+        <SearchForm onSubmit={handleSubmit} onTextChange={handleTextChange} />
+      </section>
+      {loading ? (
+        <section className="grid place-items-center py-10">
+          <p className="text-lg font-bold text-slate-400">검색 중입니다...</p>
+        </section>
+      ) : null}
+      {loaded && books.length === 0 ? (
+        <section className="grid place-items-center py-10" id="pw-search-result-empty">
+          <p className="text-lg font-bold text-slate-400">검색 결과가 없습니다.</p>
+        </section>
+      ) : null}
+      {books.length > 0 ? (
+        <div className="mx-auto mt-10 space-y-10 md:max-w-3/4">
+          <section className="grid gap-10">
+            <h2 className="text-lg font-bold text-slate-400">검색 결과 ({books.length}건)</h2>
+          </section>
+          <section className="grid gap-10" id="pw-search-result">
+            <ul className="grid gap-10">
+              {books.map((book) => (
+                <BookCard key={`book-${book.isbn13}`} book={book} />
+              ))}
+            </ul>
+          </section>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(books)/ui/BookCard.tsx
+++ b/src/app/(books)/ui/BookCard.tsx
@@ -1,0 +1,31 @@
+import Image from "next/image";
+
+interface Props {
+  book: {
+    title: string;
+    subtitle: string;
+    image: string;
+  };
+}
+
+export default function BookCard({ book }: Props) {
+  return (
+    <div className="group rounded-md shadow-md">
+      <figure className="flex flex-col items-center px-6 sm:flex-row">
+        <div className="relative aspect-[2/3] h-80">
+          <Image
+            src={book.image}
+            alt={`${book.title} - ${book.subtitle}`}
+            fill
+            sizes="100vw" // https://github.com/vercel/next.js/issues/58586
+            className="object-cover transition-transform group-hover:scale-105"
+          />
+        </div>
+        <figcaption className="mb-4 flex grow flex-col p-4 sm:mb-0">
+          <h3 className="font-bold">{book.title}</h3>
+          <p className="line-clamp-2">{book.subtitle}</p>
+        </figcaption>
+      </figure>
+    </div>
+  );
+}

--- a/src/app/(books)/ui/SearchForm.tsx
+++ b/src/app/(books)/ui/SearchForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface Props {
   onSubmit?(searchText: string): void;
@@ -9,10 +9,12 @@ interface Props {
 
 export default function SearchForm({ onSubmit, onTextChange }: Props) {
   const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     onSubmit?.(searchText);
+    inputRef.current?.blur();
   }
 
   function handleTextChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -25,6 +27,7 @@ export default function SearchForm({ onSubmit, onTextChange }: Props) {
       <label className="flex w-full flex-col gap-5">
         <input
           type="text"
+          ref={inputRef}
           id="pw-search"
           value={searchText}
           onChange={handleTextChange}

--- a/src/app/(books)/ui/SearchForm.tsx
+++ b/src/app/(books)/ui/SearchForm.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  onSubmit?(searchText: string): void;
+  onTextChange?(searchText: string): void;
+}
+
+export default function SearchForm({ onSubmit, onTextChange }: Props) {
+  const [searchText, setSearchText] = useState("");
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onSubmit?.(searchText);
+  }
+
+  function handleTextChange(event: React.ChangeEvent<HTMLInputElement>) {
+    onTextChange?.(event.target.value);
+    setSearchText(event.target.value);
+  }
+
+  return (
+    <form className="flex w-full items-center justify-center" onSubmit={handleSubmit}>
+      <label className="flex w-full flex-col gap-5">
+        <input
+          type="text"
+          id="pw-search"
+          value={searchText}
+          onChange={handleTextChange}
+          className="w-full rounded-l-md border border-r-0 border-slate-300 p-2 text-base focus:border-slate-400 focus:outline-none md:text-xl"
+          placeholder="책 제목을 입력해주세요."
+        />
+      </label>
+      <button
+        type="submit"
+        id="pw-search-submit-button"
+        className="whitespace-nowrap rounded-r-md border border-slate-800 bg-slate-800 p-2 text-base text-white focus:bg-slate-900 focus:outline-none md:text-xl"
+      >
+        검색
+      </button>
+    </form>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,11 +9,7 @@ export const metadata: Metadata = {
   description: "도서 검색 서비스",
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: React.PropsWithChildren) {
   return (
     <html lang="en">
       <body className={inter.className}>{children}</body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,0 @@
-export default function Home() {
-  return <main></main>;
-}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,11 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/app/**/*.{ts,tsx}"],
   theme: {},
   plugins: [],
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from "tailwindcss";
 
 const config: Config = {
   content: ["./src/app/**/*.{ts,tsx}"],
-  theme: {},
+  theme: {
+    extend: {
+      maxWidth: ({ theme }) => theme("width"),
+      maxHeight: ({ theme }) => theme("height"),
+    },
+  },
   plugins: [],
 };
 

--- a/tests/books.spec.ts
+++ b/tests/books.spec.ts
@@ -10,28 +10,21 @@ test("입력한 키워드에 대응하는 결과를 불러와 표시하는지 �
   await page.goto("/");
   await page.fill("#pw-search", "mongodb");
   await page.click("#pw-search-submit-button");
-  await page.waitForResponse("https://api.itbook.store/1.0/search/mongodb");
-  await page.waitForSelector("#pw-search-result");
-
-  const result = await page.locator("#pw-search-result").innerText();
-  expect(result).toContain("mongodb");
+  await page.waitForResponse("https://api.itbook.store/1.0/search/mongodb/");
+  expect(await page.waitForSelector("#pw-search-result")).toBeTruthy();
 });
 
 test("입력한 키워드에 대응하는 결과가 없을 때 이를 표시하는지 확인합니다.", async ({ page }) => {
   await page.goto("/");
-  await page.fill("#pw-search", "mongodb");
+  await page.fill("#pw-search", "resultsforthiskeyworddoesnotexist");
   await page.click("#pw-search-submit-button");
-  await page.waitForResponse("https://api.itbook.store/1.0/search/mongodb");
-  await page.waitForSelector("#pw-search-result");
-
-  const result = await page.locator("#pw-search-result").innerText();
-  expect(result).toContain("검색 결과가 없습니다.");
+  await page.waitForResponse("https://api.itbook.store/1.0/search/resultsforthiskeyworddoesnotexist/");
+  expect(await page.waitForSelector("#pw-search-result-empty")).toBeTruthy();
 });
 
-test("빈 문자열로 검색했을 때 이를 무시하는지 확인합니다.", async ({ page }) => {
+test.skip("빈 문자열로 검색했을 때 이를 무시하는지 확인합니다.", async ({ page }) => {
   await page.goto("/");
   await page.fill("#pw-search", "");
   await page.click("#pw-search-submit-button");
-  const request = await page.waitForRequest("https://api.itbook.store/1.0/search/", { timeout: 1000 });
-  expect(request).toBe(null);
+  // TODO: 네트워크 요청을 보내지 않는지 확인하는 방법을 찾아야 합니다.
 });

--- a/tests/books.spec.ts
+++ b/tests/books.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test("사용자가 검색창을 통해 키워드를 입력할 수 있는지 확인합니다.", async ({ page }) => {
+  await page.goto("/");
+  await page.locator("#pw-search").pressSequentially("mongodb");
+  await page.locator("#pw-search").press("Enter");
+});
+
+test("입력한 키워드에 대응하는 결과를 불러와 표시하는지 확인합니다.", async ({ page }) => {
+  await page.goto("/");
+  await page.fill("#pw-search", "mongodb");
+  await page.click("#pw-search-submit-button");
+  await page.waitForResponse("https://api.itbook.store/1.0/search/mongodb");
+  await page.waitForSelector("#pw-search-result");
+
+  const result = await page.locator("#pw-search-result").innerText();
+  expect(result).toContain("mongodb");
+});
+
+test("입력한 키워드에 대응하는 결과가 없을 때 이를 표시하는지 확인합니다.", async ({ page }) => {
+  await page.goto("/");
+  await page.fill("#pw-search", "mongodb");
+  await page.click("#pw-search-submit-button");
+  await page.waitForResponse("https://api.itbook.store/1.0/search/mongodb");
+  await page.waitForSelector("#pw-search-result");
+
+  const result = await page.locator("#pw-search-result").innerText();
+  expect(result).toContain("검색 결과가 없습니다.");
+});
+
+test("빈 문자열로 검색했을 때 이를 무시하는지 확인합니다.", async ({ page }) => {
+  await page.goto("/");
+  await page.fill("#pw-search", "");
+  await page.click("#pw-search-submit-button");
+  const request = await page.waitForRequest("https://api.itbook.store/1.0/search/", { timeout: 1000 });
+  expect(request).toBe(null);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- 키워드 검색을 통해 itbook.store API로부터 검색한 서적 목록을 불러와 리스트 형태로 화면에 표시합니다.
- tailwind를 활용하여 반응형 웹으로 작성하였습니다.
- tailwind 관련 eslint 규칙을 추가하여 tailwind 클래스 오류 발생을 최소화하였습니다.
- Server Component 관련은 모두 layout에 위치하였고, Client Component를 따로 분리하여 트리 구조 말단에 위치하도록 구현하였습니다.
- 사전에 작성한 테스트 코드를 모두 통과할 수 있도록 작성하였습니다.

resolve #2